### PR TITLE
Add Room 6 & 7 build routes

### DIFF
--- a/build.js
+++ b/build.js
@@ -14,7 +14,15 @@ execSync('npm run build', { stdio: 'inherit' });
 
 // Ensure all HTML files are properly copied to dist
 console.log('Ensuring all HTML files are in dist...');
-const htmlFiles = ['index.html', 'room2.html', 'room3.html', 'room4.html', 'room5.html'];
+const htmlFiles = [
+  'index.html',
+  'room2.html',
+  'room3.html',
+  'room4.html',
+  'room5.html',
+  'room6.html',
+  'room7.html'
+];
 
 htmlFiles.forEach(file => {
   // Check if the file exists in dist after build

--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,8 @@
     { "source": "/room3", "destination": "/room3.html" },
     { "source": "/room4", "destination": "/room4.html" },
     { "source": "/room5", "destination": "/room5.html" },
+    { "source": "/room6", "destination": "/room6.html" },
+    { "source": "/room7", "destination": "/room7.html" },
     { "source": "/(.*)", "destination": "/$1" }
   ],
   "cleanUrls": true,

--- a/vite.config.js
+++ b/vite.config.js
@@ -16,7 +16,9 @@ export default defineConfig({
         room2: resolve(__dirname, 'room2.html'),
         room3: resolve(__dirname, 'room3.html'),
         room4: resolve(__dirname, 'room4.html'),
-        room5: resolve(__dirname, 'room5.html')
+        room5: resolve(__dirname, 'room5.html'),
+        room6: resolve(__dirname, 'room6.html'),
+        room7: resolve(__dirname, 'room7.html')
       }
     }
   }


### PR DESCRIPTION
## Summary
- add room6/room7 inputs to Vite config
- ensure room6.html and room7.html are copied on build
- route `/room6` and `/room7` in Vercel config

## Testing
- `npm install`
- `npm run custom-build`

------
https://chatgpt.com/codex/tasks/task_e_68438cd53f14832b943959f8b459b5d9