### PR TITLE
Resolve Room7 material conflict

### DIFF
--- a/room7.js
+++ b/room7.js
@@ -133,7 +133,8 @@ imageFiles.forEach((file, index) => {
   const texture = loader.load(`/assets/Room7/${file}`);
 
   // Main image tile
-  const material = new THREE.MeshStandardMaterial({ map: texture, emissive: 0x000000 });
+  // MeshBasicMaterial keeps colors unaffected by scene lighting
+  const material = new THREE.MeshBasicMaterial({ map: texture });
   const tile = new THREE.Mesh(new THREE.PlaneGeometry(tileSize, tileSize), material);
   tile.rotation.x = -Math.PI / 2;
 


### PR DESCRIPTION
## Summary
- switch Room7 tile material to `MeshBasicMaterial`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844ec2f0b94832b9bf87ab28235d192